### PR TITLE
Feature/observers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://gitlab.com/jvenom/elixir-pre-commit-hooks
+    rev: v1.0.0
+    hooks:
+      - id: mix-format

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # WorkflowEx
 ![CI Status](https://github.com/withbelay/ex_visiflow/actions/workflows/ci.yml/badge.svg)
 
+# Todo
+
+- [ ] OpenTelemetry as an observer
+- [ ] Track state changes as an observer
+- [ ] Logging as an observer
+- [ ] Bring the workflow launcher over
+
+
 WorkflowEx is a macro that runs workflows of a very specific character. They process work linearly, and when any error is encountered, they then work backwards in that same manner.
 
 Workflow steps can be synchronous or asynchronous. Workflow steps that are asynchronous will return :continue, and then expected to subscribe to whatever events are needed to complete their task.

--- a/lib/workflow_ex/checkpointable.ex
+++ b/lib/workflow_ex/checkpointable.ex
@@ -1,0 +1,4 @@
+defprotocol WorkflowEx.Checkpointable do
+  def save(state)
+  def delete_all(state)
+end

--- a/lib/workflow_ex/fields.ex
+++ b/lib/workflow_ex/fields.ex
@@ -12,6 +12,8 @@ defmodule WorkflowEx.Fields do
   use TypedEctoSchema
   import Ecto.Changeset
 
+  @spec is_flow_state(any) ::
+          {:__block__ | {:., [], [:andalso | :erlang, ...]}, [], [{:= | {any, any, any}, list, [...]}, ...]}
   defguard is_flow_state(input) when is_map(input) and is_map_key(input, :__flow__)
 
   @primary_key false

--- a/lib/workflow_ex/messagable.ex
+++ b/lib/workflow_ex/messagable.ex
@@ -1,0 +1,3 @@
+defprotocol WorkflowEx.Messagable do
+  def send_message(state, message)
+end

--- a/lib/workflow_ex/observers/checkpointer.ex
+++ b/lib/workflow_ex/observers/checkpointer.ex
@@ -1,0 +1,12 @@
+defmodule WorkflowEx.Observers.Checkpointer do
+  use WorkflowEx.Observer
+  require Logger
+
+  @impl true
+  def handle_before_step(state), do: WorkflowEx.Checkpointable.save(state)
+
+  @impl true
+  def handle_workflow_success(state), do: WorkflowEx.Checkpointable.delete_all(state)
+
+  def handle_workflow_failure(state), do: WorkflowEx.Checkpointable.delete_all(state)
+end

--- a/lib/workflow_ex/observers/logger.ex
+++ b/lib/workflow_ex/observers/logger.ex
@@ -1,0 +1,34 @@
+defmodule WorkflowEx.Observers.Logger do
+  use WorkflowEx.Observer
+  require Logger
+
+  @impl true
+  def handle_init(state) when is_flow_state(state) do
+    Logger.info(state: state, step: "init")
+  end
+
+  @impl true
+  def handle_before_step(state) when is_flow_state(state) do
+    Logger.info(state: state, step: "before_step")
+  end
+
+  @impl true
+  def handle_after_step(state) when is_flow_state(state) do
+    Logger.info(state: state, step: "after_step")
+  end
+
+  @impl true
+  def handle_start_rollback(state) when is_flow_state(state) do
+    Logger.info(state: state, step: "start_rollback")
+  end
+
+  @impl true
+  def handle_workflow_success(state) when is_flow_state(state) do
+    Logger.info(state: state, step: "workflow_success")
+  end
+
+  @impl true
+  def handle_workflow_failure(state) when is_flow_state(state) do
+    Logger.info(state: state, step: "workflow_failure")
+  end
+end

--- a/lib/workflow_ex/observers/messager.ex
+++ b/lib/workflow_ex/observers/messager.ex
@@ -1,0 +1,28 @@
+defmodule WorkflowEx.Observers.Messager do
+  use WorkflowEx.Observer
+  alias WorkflowEx.Messagable
+  require Logger
+
+  @impl true
+  def handle_init(state), do: Messagable.send_message(state, :init)
+
+  @impl true
+  def handle_before_step(state), do: Messagable.send_message(state, :before_step)
+
+  @impl true
+  def handle_after_step(state) do
+    case WorkflowEx.Fields.get(state, :last_result) do
+      :ok -> Messagable.send_message(state, :after_step)
+      _ -> :ok
+    end
+  end
+
+  @impl true
+  def handle_workflow_success(state), do: Messagable.send_message(state, :workflow_success)
+
+  @impl true
+  def handle_start_rollback(state), do: Messagable.send_message(state, :start_rollback)
+
+  @impl true
+  def handle_workflow_failure(state), do: Messagable.send_message(state, :workflow_failure)
+end

--- a/lib/workflow_ex/observers/messager.ex
+++ b/lib/workflow_ex/observers/messager.ex
@@ -12,8 +12,11 @@ defmodule WorkflowEx.Observers.Messager do
   @impl true
   def handle_after_step(state) do
     case WorkflowEx.Fields.get(state, :last_result) do
-      :ok -> Messagable.send_message(state, :after_step)
-      _ -> :ok
+      :ok ->
+        Messagable.send_message(state, :after_step)
+
+      _ ->
+        :ok
     end
   end
 

--- a/lib/workflow_ex/step.ex
+++ b/lib/workflow_ex/step.ex
@@ -3,10 +3,10 @@ defmodule WorkflowEx.Step do
   Provides default implementations for step funcs, and marks it as implementing the appropriate behaviour
   """
   @callback run(WorkflowEx.flow_state()) :: {:ok | :continue | :error | atom(), WorkflowEx.flow_state()}
-  @callback run_continue(WorkflowEx.flow_state(), atom()) ::
+  @callback run_continue(atom, WorkflowEx.flow_state()) ::
               {:ok | :continue | :error | atom(), WorkflowEx.flow_state()}
   @callback rollback(WorkflowEx.flow_state()) :: {:ok | :continue | :error | atom(), WorkflowEx.flow_state()}
-  @callback rollback_continue(WorkflowEx.flow_state(), atom()) ::
+  @callback rollback_continue(atom(), WorkflowEx.flow_state()) ::
               {:ok | :continue | :error | atom(), WorkflowEx.flow_state()}
   defmacro __using__(_) do
     quote do

--- a/test/support/test_observers.ex
+++ b/test/support/test_observers.ex
@@ -1,0 +1,62 @@
+defmodule WorkflowEx.TestObserver do
+  use WorkflowEx.Observer
+  alias WorkflowEx.TestState
+
+  @impl true
+  def handle_init(state) when is_flow_state(state), do: run_observer(:handle_init, state)
+
+  @impl true
+  def handle_before_step(state), do: run_observer(:handle_before_step, state)
+
+  @impl true
+  def handle_after_step(state), do: run_observer(:handle_after_step, state)
+
+  @impl true
+  def handle_start_rollback(state), do: run_observer(:handle_start_rollback, state)
+
+  @impl true
+  def handle_workflow_success(state), do: run_observer(:handle_workflow_success, state)
+
+  @impl true
+  def handle_workflow_failure(state), do: run_observer(:handle_workflow_failure, state)
+
+  defp run_observer(func, state), do: TestState.run_observer(state, __MODULE__, func, :ok)
+end
+
+defmodule WorkflowEx.TestObserver2 do
+  use WorkflowEx.Observer
+  alias WorkflowEx.TestState
+
+  def handle_before_step(state) do
+    TestState.run_observer(state, __MODULE__, :handle_before_step, :ok)
+  end
+
+  def handle_after_step(%TestState{} = state) do
+    TestState.run_observer(state, __MODULE__, :handle_after_step, :ok)
+  end
+end
+
+defmodule WorkflowEx.RaisingObserver do
+  use WorkflowEx.Observer
+  alias WorkflowEx.TestState
+
+  def handle_init(%TestState{} = state) do
+    TestState.run_observer(state, __MODULE__, :handle_init, :ok)
+    raise RuntimeError, "init"
+  end
+
+  def handle_before_step(%TestState{} = state) do
+    TestState.run_observer(state, __MODULE__, :handle_before_step, :ok)
+    raise RuntimeError, "before_step"
+  end
+
+  def handle_after_step(%TestState{} = state) do
+    TestState.run_observer(state, __MODULE__, :handle_after_step, :ok)
+    raise RuntimeError, "after_step"
+  end
+
+  def handle_workflow_success(%TestState{} = state) do
+    TestState.run_observer(state, __MODULE__, :handle_after_workflow_success, :ok)
+    raise RuntimeError, "workflow_success"
+  end
+end

--- a/test/support/test_state.ex
+++ b/test/support/test_state.ex
@@ -1,0 +1,59 @@
+defmodule WorkflowEx.TestState do
+  alias WorkflowEx.TestState
+
+  import WorkflowEx.Fields, only: [is_flow_state: 1]
+  use TypedEctoSchema
+  use WorkflowEx.TypedSchemaHelpers
+
+  @primary_key false
+  typed_embedded_schema do
+    embeds_one :__flow__, WorkflowEx.Fields
+    field(:agent, WorkflowEx.Pid, virtual: true)
+    field(:execution_order, {:array, :string})
+  end
+
+  def new do
+    {:ok, agent} = StateAgent.start_link()
+    new!(%{agent: agent})
+  end
+
+  def_new(
+    required: :none,
+    default: [
+      {:execution_order, []},
+      {:__flow__, %WorkflowEx.Fields{} |> Map.from_struct()}
+    ]
+  )
+
+  def run_observer(%TestState{} = state, step_module, step_func, step_result) when is_flow_state(state) do
+    run_step(state, step_module, step_func, step_result)
+  end
+
+  @spec run_step(WorkflowEx.TestState.t(), atom(), atom(), atom()) :: {atom(), WorkflowEx.TestState.t()}
+  def run_step(%TestState{} = state, step_module, step_func, step_result) do
+    # NOTE - DO NOT CHANGE VALUES VISIFLOW OWNS - It must do that
+    full_step = {step_module, step_func}
+
+    agent_state =
+      case StateAgent.get(state.agent) do
+        %TestState{} = agent_state ->
+          %TestState{
+            __flow__: state.__flow__,
+            execution_order: agent_state.execution_order,
+            agent: agent_state.agent
+          }
+
+        _ ->
+          state
+      end
+
+    agent_state =
+      agent_state
+      |> Map.update(:execution_order, [full_step], fn current ->
+        current ++ List.wrap(full_step)
+      end)
+
+    StateAgent.set(agent_state.agent, agent_state)
+    {step_result, agent_state}
+  end
+end

--- a/test/support/test_state.ex
+++ b/test/support/test_state.ex
@@ -7,7 +7,7 @@ defmodule WorkflowEx.TestState do
 
   @primary_key false
   typed_embedded_schema do
-    embeds_one :__flow__, WorkflowEx.Fields
+    embeds_one(:__flow__, WorkflowEx.Fields)
     field(:agent, WorkflowEx.Pid, virtual: true)
     field(:execution_order, {:array, :string})
   end
@@ -25,11 +25,13 @@ defmodule WorkflowEx.TestState do
     ]
   )
 
-  def run_observer(%TestState{} = state, step_module, step_func, step_result) when is_flow_state(state) do
+  def run_observer(%TestState{} = state, step_module, step_func, step_result)
+      when is_flow_state(state) do
     run_step(state, step_module, step_func, step_result)
   end
 
-  @spec run_step(WorkflowEx.TestState.t(), atom(), atom(), atom()) :: {atom(), WorkflowEx.TestState.t()}
+  @spec run_step(WorkflowEx.TestState.t(), atom(), atom(), atom()) ::
+          {atom(), WorkflowEx.TestState.t()}
   def run_step(%TestState{} = state, step_module, step_func, step_result) do
     # NOTE - DO NOT CHANGE VALUES VISIFLOW OWNS - It must do that
     full_step = {step_module, step_func}
@@ -55,5 +57,36 @@ defmodule WorkflowEx.TestState do
 
     StateAgent.set(agent_state.agent, agent_state)
     {step_result, agent_state}
+  end
+end
+
+defmodule CheckpointableState do
+  defstruct [:run]
+
+  defimpl WorkflowEx.Checkpointable do
+    def save(_state), do: :save
+
+    def delete_all(_state), do: :delete_all
+  end
+end
+
+defmodule MessagableState do
+  use TypedEctoSchema
+  use WorkflowEx.TypedSchemaHelpers
+
+  @primary_key false
+  typed_embedded_schema do
+    embeds_one(:__flow__, WorkflowEx.Fields)
+  end
+
+  def_new(
+    required: :none,
+    default: [
+      {:__flow__, %WorkflowEx.Fields{} |> Map.from_struct()}
+    ]
+  )
+
+  defimpl WorkflowEx.Messagable do
+    def send_message(_state, message), do: message
   end
 end

--- a/test/support/test_steps.ex
+++ b/test/support/test_steps.ex
@@ -1,174 +1,78 @@
-defmodule WorkflowEx.TestSteps do
-  alias WorkflowEx.TestSteps
-
-  use TypedEctoSchema
-  use WorkflowEx.TypedSchemaHelpers
-
-  @primary_key false
-  typed_embedded_schema do
-    embeds_one :__flow__, WorkflowEx.Fields
-    field(:agent, WorkflowEx.Pid, virtual: true)
-    field(:execution_order, {:array, :string})
-  end
-
-  def new do
-    {:ok, agent} = StateAgent.start_link()
-    new!(%{agent: agent})
-  end
-
-  def_new(
-    required: :none,
-    default: [
-      {:execution_order, []},
-      {:__flow__, %WorkflowEx.Fields{} |> Map.from_struct()}
-    ]
-  )
-
-  def run_observer(%TestSteps{} = state, step_module, step_func, step_result) do
-    run_step(state, step_module, step_func, step_result)
-  end
-
-  @spec run_step(WorkflowEx.TestSteps.t(), atom(), atom(), atom()) :: {atom(), WorkflowEx.TestSteps.t()}
-  def run_step(%TestSteps{} = state, step_module, step_func, step_result) do
-    # NOTE - DO NOT CHANGE VALUES VISIFLOW OWNS - It must do that
-    full_step = {step_module, step_func}
-
-    agent_state =
-      case StateAgent.get(state.agent) do
-        %TestSteps{} = agent_state ->
-          %TestSteps{
-            __flow__: state.__flow__,
-            execution_order: agent_state.execution_order,
-            agent: agent_state.agent
-          }
-
-        _ ->
-          state
-      end
-
-    agent_state =
-      agent_state
-      |> Map.update(:execution_order, [full_step], fn current ->
-        current ++ List.wrap(full_step)
-      end)
-
-    StateAgent.set(agent_state.agent, agent_state)
-    {step_result, agent_state}
-  end
-end
-
 defmodule WorkflowEx.StepOk do
   use WorkflowEx.Step
-  alias WorkflowEx.TestSteps
-  def run(%TestSteps{} = state), do: TestSteps.run_step(state, __MODULE__, :run, :ok)
-  def rollback(%TestSteps{} = state), do: TestSteps.run_step(state, __MODULE__, :rollback, :ok)
+  alias WorkflowEx.TestState
+
+  @impl true
+  def run(%TestState{} = state), do: TestState.run_step(state, __MODULE__, :run, :ok)
+
+  @impl true
+  def rollback(%TestState{} = state), do: TestState.run_step(state, __MODULE__, :rollback, :ok)
 end
 
 defmodule WorkflowEx.StepOk2 do
-  alias WorkflowEx.TestSteps
-  def run(%TestSteps{} = state), do: TestSteps.run_step(state, __MODULE__, :run, :ok)
+  use WorkflowEx.Step
+  alias WorkflowEx.TestState
+  @impl true
+  def run(%TestState{} = state), do: TestState.run_step(state, __MODULE__, :run, :ok)
 
-  def rollback(%TestSteps{} = state), do: TestSteps.run_step(state, __MODULE__, :rollback, :ok)
+  @impl true
+  def rollback(%TestState{} = state), do: TestState.run_step(state, __MODULE__, :rollback, :ok)
 end
 
 defmodule WorkflowEx.StepError do
-  alias WorkflowEx.TestSteps
-  def run(%TestSteps{} = state), do: TestSteps.run_step(state, __MODULE__, :run, :error)
+  use WorkflowEx.Step
+  alias WorkflowEx.TestState
+  @impl true
+  def run(%TestState{} = state), do: TestState.run_step(state, __MODULE__, :run, :error)
 
-  def rollback(%TestSteps{} = state), do: TestSteps.run_step(state, __MODULE__, :rollback, :ok)
+  @impl true
+  def rollback(%TestState{} = state), do: TestState.run_step(state, __MODULE__, :rollback, :ok)
 end
 
 defmodule WorkflowEx.AsyncStepOk do
-  alias WorkflowEx.TestSteps
-  @spec run(WorkflowEx.TestSteps.t()) :: {atom(), WorkflowEx.TestSteps.t()}
-  def run(%TestSteps{} = state), do: TestSteps.run_step(state, __MODULE__, :run, :continue)
+  use WorkflowEx.Step
+  alias WorkflowEx.TestState
 
+  @impl true
+  def run(%TestState{} = state), do: TestState.run_step(state, __MODULE__, :run, :continue)
+
+  @impl true
   def run_continue(WorkflowEx.AsyncStepOk, state) do
-    TestSteps.run_step(state, __MODULE__, :run_continue, :ok)
+    TestState.run_step(state, __MODULE__, :run_continue, :ok)
   end
 
-  def rollback(%TestSteps{} = state), do: TestSteps.run_step(state, __MODULE__, :rollback, :ok)
+  @impl true
+  def rollback(%TestState{} = state), do: TestState.run_step(state, __MODULE__, :rollback, :ok)
 end
 
 defmodule WorkflowEx.AsyncStepOk2 do
-  alias WorkflowEx.TestSteps
-  def run(%TestSteps{} = state), do: TestSteps.run_step(state, __MODULE__, :run, :continue)
+  use WorkflowEx.Step
+  alias WorkflowEx.TestState
 
+  @impl true
+  def run(%TestState{} = state), do: TestState.run_step(state, __MODULE__, :run, :continue)
+
+  @impl true
   def run_continue(WorkflowEx.AsyncStepOk2, state) do
-    TestSteps.run_step(state, __MODULE__, :run_continue, :ok)
+    TestState.run_step(state, __MODULE__, :run_continue, :ok)
   end
 
-  def rollback(%TestSteps{} = state), do: TestSteps.run_step(state, __MODULE__, :rollback, :ok)
+  @impl true
+  def rollback(%TestState{} = state), do: TestState.run_step(state, __MODULE__, :rollback, :ok)
 end
 
 defmodule WorkflowEx.AsyncStepError do
-  alias WorkflowEx.TestSteps
-  def run(%TestSteps{} = state), do: TestSteps.run_step(state, __MODULE__, :run, :continue)
+  use WorkflowEx.Step
+  alias WorkflowEx.TestState
 
+  @impl true
+  def run(%TestState{} = state), do: TestState.run_step(state, __MODULE__, :run, :continue)
+
+  @impl true
   def run_continue(WorkflowEx.AsyncStepError, state) do
-    TestSteps.run_step(state, __MODULE__, :run_continue, :error)
+    TestState.run_step(state, __MODULE__, :run_continue, :error)
   end
-
-  def rollback(%TestSteps{} = state), do: TestSteps.run_step(state, __MODULE__, :rollback, :ok)
-end
-
-defmodule WorkflowEx.TestObserver do
-  use WorkflowEx.Observer
-  alias WorkflowEx.TestSteps
 
   @impl true
-  def handle_init(state), do: run_observer(:handle_init, state)
-
-  def handle_before_step(%TestSteps{} = state), do: run_observer(:handle_before_step, state)
-
-  def handle_after_step(%TestSteps{} = state), do: run_observer(:handle_after_step, state)
-
-  @impl true
-  def handle_start_rollback(state), do: run_observer(:handle_start_rollback, state)
-
-  @impl true
-  def handle_workflow_success(state), do: run_observer(:handle_workflow_success, state)
-
-  @impl true
-  def handle_workflow_failure(state), do: run_observer(:handle_workflow_failure, state)
-
-  defp run_observer(func, state), do: TestSteps.run_observer(state, __MODULE__, func, :ok)
-end
-
-defmodule WorkflowEx.TestObserver2 do
-  use WorkflowEx.Observer
-  alias WorkflowEx.TestSteps
-
-  def handle_before_step(%TestSteps{} = state) do
-    TestSteps.run_observer(state, __MODULE__, :handle_before_step, :ok)
-  end
-
-  def handle_after_step(%TestSteps{} = state) do
-    TestSteps.run_observer(state, __MODULE__, :handle_after_step, :ok)
-  end
-end
-
-defmodule WorkflowEx.RaisingObserver do
-  use WorkflowEx.Observer
-  alias WorkflowEx.TestSteps
-
-  def handle_init(%TestSteps{} = state) do
-    TestSteps.run_observer(state, __MODULE__, :handle_init, :ok)
-    raise RuntimeError, "init"
-  end
-
-  def handle_before_step(%TestSteps{} = state) do
-    TestSteps.run_observer(state, __MODULE__, :handle_before_step, :ok)
-    raise RuntimeError, "before_step"
-  end
-
-  def handle_after_step(%TestSteps{} = state) do
-    TestSteps.run_observer(state, __MODULE__, :handle_after_step, :ok)
-    raise RuntimeError, "after_step"
-  end
-
-  def handle_workflow_success(%TestSteps{} = state) do
-    TestSteps.run_observer(state, __MODULE__, :handle_after_workflow_success, :ok)
-    raise RuntimeError, "workflow_success"
-  end
+  def rollback(%TestState{} = state), do: TestState.run_step(state, __MODULE__, :rollback, :ok)
 end

--- a/test/workflow_ex/observers/checkpointer_test.exs
+++ b/test/workflow_ex/observers/checkpointer_test.exs
@@ -1,0 +1,21 @@
+defmodule WorkflowEx.Observers.CheckpointerTest do
+  use ExUnit.Case, async: true
+  doctest WorkflowEx.Observers.Checkpointer
+  alias WorkflowEx.Observers.Checkpointer
+
+  setup do
+    %{state: %CheckpointableState{}}
+  end
+
+  test "handle_before_step/1", %{state: state} do
+    assert Checkpointer.handle_before_step(state) == :save
+  end
+
+  test "handle_workflow_success/1", %{state: state} do
+    assert Checkpointer.handle_workflow_success(state) == :delete_all
+  end
+
+  test "handle_workflow_failure/1", %{state: state} do
+    assert Checkpointer.handle_workflow_failure(state) == :delete_all
+  end
+end

--- a/test/workflow_ex/observers/logger_test.exs
+++ b/test/workflow_ex/observers/logger_test.exs
@@ -1,0 +1,31 @@
+defmodule WorkflowEx.Observers.LoggerTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+  alias WorkflowEx.TestState
+
+  setup do
+    Process.flag(:trap_exit, true)
+    {:ok, %{test_steps: TestState.new()}}
+  end
+
+  describe "LoggerTest" do
+    defmodule SuccessfulLoggingObserverTest do
+      use WorkflowEx,
+        steps: [WorkflowEx.StepOk, WorkflowEx.StepOk2],
+        observers: [WorkflowEx.Observers.Logger]
+    end
+
+    test "Logger logs the things on success", %{test_steps: test_steps} do
+      log =
+        capture_log([format: "$time JEFFF $metadata: $message\n"], fn ->
+          assert {:ok, pid} = SuccessfulLoggingObserverTest.start_link(test_steps)
+          assert_receive {:EXIT, ^pid, :normal}
+        end)
+
+      assert log =~ "init"
+      assert log =~ "before_step"
+      assert log =~ "after_step"
+      assert log =~ "workflow_success"
+    end
+  end
+end

--- a/test/workflow_ex/observers/messager_test.exs
+++ b/test/workflow_ex/observers/messager_test.exs
@@ -1,0 +1,36 @@
+defmodule WorkflowEx.Observers.MessagerTest do
+  use ExUnit.Case, async: true
+  doctest WorkflowEx.Observers.Messager
+  alias WorkflowEx.Observers.Messager
+  alias WorkflowEx.Fields
+
+  setup do
+    %{state: MessagableState.new!(%{})}
+  end
+
+  test "handle_init/1", %{state: state} do
+    assert Messager.handle_init(state) == :init
+  end
+
+  test "handle_before_step/1", %{state: state} do
+    assert Messager.handle_before_step(state) == :before_step
+  end
+
+  test "handle_after_step/1", %{state: state} do
+    assert Messager.handle_after_step(state) == :after_step
+    state = %{state | __flow__: Fields.merge(state, %{last_result: :error})}
+    assert Messager.handle_after_step(state) == :ok
+  end
+
+  test "handle_workflow_success/1", %{state: state} do
+    assert Messager.handle_workflow_success(state) == :workflow_success
+  end
+
+  test "handle_start_rollback/1", %{state: state} do
+    assert Messager.handle_start_rollback(state) == :start_rollback
+  end
+
+  test "handle_workflow_failure/1", %{state: state} do
+    assert Messager.handle_workflow_failure(state) == :workflow_failure
+  end
+end

--- a/test/workflow_ex_test.exs
+++ b/test/workflow_ex_test.exs
@@ -2,14 +2,15 @@ defmodule WorkflowExTest do
   use ExUnit.Case
   use AssertEventually, timeout: 50, interval: 5
 
-  alias WorkflowEx.TestSteps
+  alias WorkflowEx.TestState
   alias WorkflowEx.Fields
 
   doctest WorkflowEx
+  @moduletag :capture_log
 
   setup do
     Process.flag(:trap_exit, true)
-    {:ok, %{test_steps: TestSteps.new()}}
+    {:ok, %{test_steps: TestState.new()}}
   end
 
   defmodule JustStart do
@@ -58,7 +59,7 @@ defmodule WorkflowExTest do
 
       test "src: #{src}, result: #{result}, dir: #{direction}, step: #{if current_step == @first_step, do: "first", else: "last"} should return #{inspect(expected_response)}}" do
         test_steps =
-          TestSteps.new!(%{
+          TestState.new!(%{
             __flow__: %{
               lifecycle_src: @src,
               last_result: @result,
@@ -373,7 +374,7 @@ defmodule WorkflowExTest do
 
   test "in_rollback?" do
     state =
-      TestSteps.new()
+      TestState.new()
       |> Fields.merge(%{direction: :up})
 
     refute WorkflowEx.in_rollback?(state)
@@ -384,7 +385,7 @@ defmodule WorkflowExTest do
 
   test "rollback\1 ensures that any state that comes in leaves in rollback mode" do
     state =
-      TestSteps.new()
+      TestState.new()
       |> Fields.merge(%{direction: :up})
       |> WorkflowEx.rollback(:because_i_said_so)
 


### PR DESCRIPTION
The observers really just represent collections of event handlers that can be grouped together to provide the framework for some functionality. The checkpointer knows when to checkpoint, and when to delete checkpoints, but not how.

The messaging has the same capability. 

So this pulls in observers from belay, and invokes them via protocols that users can implement to get the desired functionality