### PR TITLE
Prefer string to atom

### DIFF
--- a/lib/workflow_ex/atom.ex
+++ b/lib/workflow_ex/atom.ex
@@ -10,10 +10,10 @@ defmodule WorkflowEx.Atom do
 
   def type, do: :string
 
-  def cast(value) when is_binary(value), do: {:ok, String.to_existing_atom(value)}
+  def cast(value) when is_binary(value), do: {:ok, String.to_atom(value)}
   def cast(value) when is_atom(value), do: {:ok, value}
 
-  def load(value), do: {:ok, String.to_existing_atom(value)}
+  def load(value), do: {:ok, String.to_atom(value)}
   def dump(value) when is_atom(value), do: {:ok, Atom.to_string(value)}
   def dump(_), do: :error
 end


### PR DESCRIPTION
- [x] Prefer `String.to_atom` over `String.to_existing_atom`